### PR TITLE
Add text utility boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,23 @@
-**MDify: Streamline Your Content Creation**
-=============================================
+# MDify Utils
 
-MDify is a powerful tool that converts your content into Markdown, saving you time and effort. Whether you're a developer, writer, or student, MDify helps you focus on what matters most - creating high-quality content.
+MDify Utils is a collection of paste-in tools for quick text cleanup and conversion. Each panel runs immediately on input with no configuration.
 
-**Key Features**
+## Panels
 
-* Lightning-fast conversion: Get your content in Markdown format in seconds
-* @todo:Customizable: Tailor the conversion process to your specific needs
-* Easy to use: Simple and intuitive interface for effortless content creation
+- **Emdash Fix** — replaces every emdash with `; `.
+- **Trim Blank Lines** — removes lines that contain only tabs or spaces.
+- **Remove /* */** — strips multiline comments from code snippets.
+- **MD ➜ Rich** — converts Markdown to HTML.
+- **Rich ➜ MD** — converts HTML or rich text to Markdown.
+- **HTML ➜ MD** — converts raw HTML to Markdown.
+- **MD ➜ HTML** — converts Markdown to HTML.
+- **Stats** — shows counts and reading metrics for the text.
+- **Sort Lines** — deduplicates and sorts lines; toggle Asc/Desc.
 
-**What Sets MDify Apart**
+## Usage
 
-* Unparalleled flexibility: Convert from a wide range of formats, including HTML, Google Docs, and PDFs
-* @todo:Precision control: Fine-tune your Markdown output with custom rules and settings
-* Seamless integration: Use MDify with your favorite tools and workflows
+1. Open `index.html` in your browser.
+2. Paste text into any panel.
+3. Copy the transformed output from the paired field.
 
-**Get Started**
-
-1. Open MDify in your browser
-2. Paste your content into the input area
-3. Watch as MDify converts your content to Markdown instantly
-4. Modify `style.css` or `script.js` for custom behavior
-
-**Contribute**
-
-MDify is an open-source project. If you'd like to report an issue, suggest a feature, or contribute code, please create a pull request or issue on this repository.
-
-**Improvement Suggestions**
-
-[ ] 1. Implement support for converting tables from HTML to Markdown
-[ ] 2. Add an option to preserve or remove formatting for specific HTML elements
-[ ] 3. Develop a feature to automatically detect and convert inline styles to Markdown syntax
-[ ] 4. Create a settings panel to allow users to customize the conversion process
-[ ] 5. Integrate a syntax highlighter to display the converted Markdown code with proper formatting
-
-**License**
-
-MDify is licensed under the MIT License.
+MIT License.

--- a/index.html
+++ b/index.html
@@ -1,22 +1,64 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>MDify</title>
-                <link rel="stylesheet" href="style.css" />
-		<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/turndown/6.0.0/turndown.min.js"></script>
-                <script src="script.js" defer></script>
-        </head>
-	<body class="fp_flex">
-		<div class="theme_switcher">Toggle Theme</div>
-		<header class="fp_flex flex_head">
-            <h1>MDify</h1>
-            <p>Transform your content in seconds with FunkProductions' MDify. A powerful tool that converts HTML, Google Docs, and PDFs to Markdown. Say goodbye to tedious formatting and hello to streamlined content creation. MDify enables developers, writers, and students to easily adapt their text to Markdown, making it perfect for use with Large Language Models like ChatGPT. Whether you're updating legacy documents for long-term archiving or creating internal documentation, MDify simplifies the process of converting your text to Markdown, saving you time and effort. Get started now and discover the benefits of Markdown formatting!</p>
-        </header>
-		<section class="fp_flex flex_panel">
-			<div id="input_area" class="editable_area fp_border" contenteditable></div>
-			<textarea id="output_area" class="editable_area fp_border"></textarea>
-		</section>
-        </body>
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MDify Utils</title>
+<link rel="stylesheet" href="style.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/turndown/6.0.0/turndown.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.3.0/marked.min.js"></script>
+<script src="script.js" defer></script>
+</head>
+<body>
+<div class="theme_switcher">Toggle Theme</div>
+<h1>MDify Utils</h1>
+<div class="grid">
+  <div id="dash_box" class="card vivid1">
+    <h2>Emdash Fix</h2>
+    <textarea class="in"></textarea>
+    <textarea class="out"></textarea>
+  </div>
+  <div id="blank_box" class="card vivid2">
+    <h2>Trim Blank Lines</h2>
+    <textarea class="in"></textarea>
+    <textarea class="out"></textarea>
+  </div>
+  <div id="comment_box" class="card vivid3">
+    <h2>Remove /* */</h2>
+    <textarea class="in"></textarea>
+    <textarea class="out"></textarea>
+  </div>
+  <div id="md_to_rich" class="card vivid4">
+    <h2>MD ➜ Rich</h2>
+    <textarea class="in"></textarea>
+    <textarea class="out"></textarea>
+  </div>
+  <div id="rich_to_md" class="card vivid5">
+    <h2>Rich ➜ MD</h2>
+    <textarea class="in"></textarea>
+    <textarea class="out"></textarea>
+  </div>
+  <div id="html_to_md" class="card vivid6">
+    <h2>HTML ➜ MD</h2>
+    <textarea class="in"></textarea>
+    <textarea class="out"></textarea>
+  </div>
+  <div id="md_to_html" class="card vivid7">
+    <h2>MD ➜ HTML</h2>
+    <textarea class="in"></textarea>
+    <textarea class="out"></textarea>
+  </div>
+  <div id="stat_box" class="card vivid8">
+    <h2>Stats</h2>
+    <textarea class="in"></textarea>
+    <pre class="out"></pre>
+  </div>
+  <div id="sort_box" class="card vivid9">
+    <h2>Sort Lines</h2>
+    <button class="sort_toggle">Asc</button>
+    <textarea class="in"></textarea>
+    <textarea class="out"></textarea>
+  </div>
+</div>
+</body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,12 @@
-const turndown = new TurndownService();
-const switcher = document.querySelector('.theme_switcher');
+const turndown = typeof TurndownService !== 'undefined'
+  ? new TurndownService()
+  : { turndown: t => t };
+const mk = typeof marked !== 'undefined'
+  ? marked
+  : { parse: t => t };
+const switcher = typeof document !== 'undefined'
+  ? document.querySelector('.theme_switcher')
+  : null;
 if (switcher) {
   switcher.addEventListener('click', () => {
     document.body.classList.toggle('dark_theme');
@@ -36,7 +43,7 @@ function stripComments(t) {
 }
 
 function mdToRich(t) {
-  return marked.parse(t);
+  return mk.parse(t);
 }
 
 function richToMd(t) {
@@ -48,7 +55,7 @@ function htmlToMd(t) {
 }
 
 function mdToHtml(t) {
-  return marked.parse(t);
+  return mk.parse(t);
 }
 
 function countSyllables(w) {
@@ -94,14 +101,16 @@ function sortLinesDesc(t) {
   return lines.join('\n');
 }
 
-attach('dash_box', replaceDash);
-attach('blank_box', trimBlank);
-attach('comment_box', stripComments);
-attach('md_to_rich', mdToRich);
-attach('rich_to_md', richToMd);
-attach('html_to_md', htmlToMd);
-attach('md_to_html', mdToHtml);
-attach('stat_box', stats);
+if (typeof document !== 'undefined') {
+  attach('dash_box', replaceDash);
+  attach('blank_box', trimBlank);
+  attach('comment_box', stripComments);
+  attach('md_to_rich', mdToRich);
+  attach('rich_to_md', richToMd);
+  attach('html_to_md', htmlToMd);
+  attach('md_to_html', mdToHtml);
+  attach('stat_box', stats);
+}
 
 function initSortBox() {
   const sortBox = document.getElementById('sort_box');
@@ -123,5 +132,19 @@ function initSortBox() {
   });
 }
 
-initSortBox();
+if (typeof document !== 'undefined') {
+  initSortBox();
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    replaceDash,
+    trimBlank,
+    stripComments,
+    countSyllables,
+    stats,
+    sortLinesAsc,
+    sortLinesDesc,
+  };
+}
 

--- a/script.js
+++ b/script.js
@@ -1,106 +1,127 @@
-const md = new TurndownService();
+const turndown = new TurndownService();
 const switcher = document.querySelector('.theme_switcher');
-const input = document.getElementById('input_area');
-const output = document.getElementById('output_area');
-
-md.addRule('h1', {filter: 'h1', replacement: c => `# ${c}\n`});
-md.addRule('h2', {filter: 'h2', replacement: c => `## ${c}\n`});
-
-md.addRule('bold_text_style', {
-  filter(node) {
-    if (node.nodeName !== 'SPAN') return false;
-    return node.style.fontWeight === 'bolder';
-  },
-  replacement: c => `**${c}**`
-});
-
-md.addRule('form', {
-  filter: 'form',
-  replacement: (c, n) => `\n## ${n.getAttribute('name') || 'Form'}\n${c.trim()}\n`
-});
-
-md.addRule('form_block', {
-  filter: 'form',
-  replacement: (c, n) => `\`\`\`form\n% #${n.getAttribute('name') || 'Form'}\n${c.trim()}\n\`\`\`\n`
-});
-
-md.addRule('input', {
-  filter(node) {
-    if (node.nodeName !== 'INPUT') return false;
-    return node.type !== 'submit';
-  },
-  replacement: (c, n) => {
-    const ph = n.getAttribute('placeholder');
-    if (ph) return `::(${ph})\n`;
-    return '::\n';
-  }
-});
-
-md.addRule('select', {
-  filter: 'select',
-  replacement: (c, n) => {
-    const labels = Array.from(n.querySelectorAll('option'))
-      .map(o => o.textContent.trim())
-      .join('|');
-    return `::${labels}`;
-  }
-});
-
-md.addRule('button', {
-  filter(node) {
-    if (node.nodeName !== 'BUTTON') return false;
-    return node.type === 'submit';
-  },
-  replacement: (c, n) => {
-    const form = n.form;
-    if (form) {
-      const url = form.getAttribute('action') || form.getAttribute('method') || '#';
-      return `[■ ${c}](${url})\n`;
-    }
-    return `[■ ${c}](#)\n`;
-  }
-});
-
-md.addRule('a_button', {
-  filter(node) {
-    if (node.nodeName !== 'A') return false;
-    if (node.classList.contains('button')) return true;
-    if (node.classList.contains('btn')) return true;
-    if (node.classList.contains('elementor-button')) return true;
-    return false;
-  },
-  replacement: (c, n) => `@[${c}](${n.getAttribute('href')})\n`
-});
-
-md.addRule('checkbox', {
-  filter(node) {
-    if (node.nodeName !== 'INPUT') return false;
-    return node.type === 'checkbox';
-  },
-  replacement: (c, n) => `\n[${n.checked ? 'x' : ' '}] `
-});
-
-md.addRule('radio', {
-  filter(node) {
-    if (node.nodeName !== 'INPUT') return false;
-    return node.type === 'radio';
-  },
-  replacement: (c, n) => `\n[${n.checked ? 'x' : ' '}] `
-});
-
-md.addRule('label', {
-  filter(node) {
-    return node.nodeName === 'LABEL';
-  },
-  replacement: c => `$${c}$\n`
-});
-
-input.addEventListener('DOMSubtreeModified', updateOutput);
-input.addEventListener('input', updateOutput);
-switcher.addEventListener('click', () => {
-  document.body.classList.toggle('dark_theme');
-});
-
-function updateOutput() {
-  output.value = md.turndown(input.innerHTML);
+if (switcher) {
+  switcher.addEventListener('click', () => {
+    document.body.classList.toggle('dark_theme');
+  });
 }
+
+function attach(id, fn) {
+  const box = document.getElementById(id);
+  if (!box) return;
+  const input = box.querySelector('.in');
+  if (!input) return;
+  const output = box.querySelector('.out');
+  if (!output) return;
+  input.addEventListener('input', () => {
+    output.value = fn(input.value);
+  });
+  if (output.tagName === 'PRE') {
+    input.addEventListener('input', () => {
+      output.textContent = fn(input.value);
+    });
+  }
+}
+
+function replaceDash(t) {
+  return t.replace(/—/g, '; ');
+}
+
+function trimBlank(t) {
+  return t.split('\n').filter(l => !/^\s*$/.test(l)).join('\n');
+}
+
+function stripComments(t) {
+  return t.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function mdToRich(t) {
+  return marked.parse(t);
+}
+
+function richToMd(t) {
+  return turndown.turndown(t);
+}
+
+function htmlToMd(t) {
+  return turndown.turndown(t);
+}
+
+function mdToHtml(t) {
+  return marked.parse(t);
+}
+
+function countSyllables(w) {
+  const m = w.toLowerCase().match(/[aeiouy]+/g);
+  if (!m) return 1;
+  return m.length;
+}
+
+function stats(t) {
+  const words = t.match(/\b\w+\b/g) || [];
+  const chars = t.length;
+  const sentences = t.split(/[.!?]+/).filter(s => s.trim()).length;
+  const paras = t.split(/\n\s*\n/).filter(p => p.trim()).length;
+  let syllables = 0;
+  for (const w of words) syllables += countSyllables(w);
+  const wps = words.length / Math.max(sentences, 1);
+  const spw = syllables / Math.max(words.length, 1);
+  const reading = 206.835 - 1.015 * wps - 84.6 * spw;
+  const readTime = words.length / 200;
+  const speakTime = words.length / 130;
+  const freq = {};
+  const stops = ['the','and','a','to','of','in','is','it','that','for'];
+  for (const w of words) {
+    const x = w.toLowerCase();
+    if (stops.includes(x)) continue;
+    freq[x] = (freq[x] || 0) + 1;
+  }
+  const sorted = Object.entries(freq).sort((a,b) => b[1]-a[1]).slice(0,10);
+  let dens = '';
+  for (const [k,v] of sorted) dens += `${k}: ${v} (${(v/words.length*100).toFixed(1)}%)\n`;
+  return `Words: ${words.length}\nChars: ${chars}\nSentences: ${sentences}\nParagraphs: ${paras}\nRead min: ${readTime.toFixed(2)}\nSpeak min: ${speakTime.toFixed(2)}\nFlesch: ${reading.toFixed(1)}\n${dens}`;
+}
+
+function sortLinesAsc(t) {
+  const lines = Array.from(new Set(t.split('\n')));
+  lines.sort((a,b) => a.localeCompare(b));
+  return lines.join('\n');
+}
+
+function sortLinesDesc(t) {
+  const lines = Array.from(new Set(t.split('\n')));
+  lines.sort((a,b) => b.localeCompare(a));
+  return lines.join('\n');
+}
+
+attach('dash_box', replaceDash);
+attach('blank_box', trimBlank);
+attach('comment_box', stripComments);
+attach('md_to_rich', mdToRich);
+attach('rich_to_md', richToMd);
+attach('html_to_md', htmlToMd);
+attach('md_to_html', mdToHtml);
+attach('stat_box', stats);
+
+function initSortBox() {
+  const sortBox = document.getElementById('sort_box');
+  if (!sortBox) return;
+  const toggle = sortBox.querySelector('.sort_toggle');
+  if (!toggle) return;
+  const input = sortBox.querySelector('.in');
+  if (!input) return;
+  const output = sortBox.querySelector('.out');
+  if (!output) return;
+  let desc = false;
+  toggle.addEventListener('click', () => {
+    desc = !desc;
+    toggle.textContent = desc ? 'Desc' : 'Asc';
+    output.value = desc ? sortLinesDesc(input.value) : sortLinesAsc(input.value);
+  });
+  input.addEventListener('input', () => {
+    output.value = desc ? sortLinesDesc(input.value) : sortLinesAsc(input.value);
+  });
+}
+
+initSortBox();
+

--- a/style.css
+++ b/style.css
@@ -1,9 +1,18 @@
 *{box-sizing:border-box;margin:0;padding:0}
-body{flex-direction:column;align-items:center;height:100vh;padding:1% 2%;background-color:#e0e0e0;color:#333;overflow: hidden}
-body.dark_theme{background-color:#333;color:#f5f5f5}
+body{font-family:sans-serif;background:#e0e0e0;color:#111;display:flex;flex-direction:column;align-items:center;padding:1rem;gap:1rem}
+body.dark_theme{background:#222;color:#eee}
 .theme_switcher{position:fixed;top:10px;right:10px;cursor:pointer}
-.fp_flex{display:flex;gap:1%;width:100%}
-.flex_head{height:calc(10vh - 1% - 2%);overflow:auto}
-.flex_panel{height:90vh;overflow:auto}
-.editable_area{flex:1;overflow-y:auto}
-.fp_border{border:solid 1px #000;box-shadow:2px 2px #000}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(250px,1fr));grid-auto-rows:200px;gap:1rem;width:100%;max-width:1200px}
+.card{display:flex;flex-direction:column;padding:.5rem;overflow:hidden;color:#000}
+.in,.out{flex:1;width:100%;margin:.25rem 0}
+pre.out{white-space:pre-wrap;overflow:auto}
+.vivid1{background:#ffeb3b}
+.vivid2{background:#ff9800}
+.vivid3{background:#f44336}
+.vivid4{background:#8bc34a}
+.vivid5{background:#03a9f4}
+.vivid6{background:#9c27b0}
+.vivid7{background:#00bcd4}
+.vivid8{background:#cddc39}
+.vivid9{background:#e91e63}
+button.sort_toggle{margin-bottom:.25rem}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+node tests/test.js > tests/test-log.txt 2>&1

--- a/tests/test-log.txt
+++ b/tests/test-log.txt
@@ -1,0 +1,1 @@
+All tests passed

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const funcs = require('../script.js');
+
+function run() {
+  assert.strictEqual(funcs.replaceDash('a—b—c'), 'a; b; c');
+
+  const cleaned = funcs.trimBlank('a\n \n\nb\n');
+  assert.strictEqual(cleaned, 'a\nb');
+
+  const noComments = funcs.stripComments('a/*x*/b');
+  assert.strictEqual(noComments, 'ab');
+
+  assert.strictEqual(funcs.countSyllables('testing'), 2);
+
+  const stats = funcs.stats('Hello world. This is a test.');
+  assert(stats.startsWith('Words: 6\nChars: 28'));
+
+  const asc = funcs.sortLinesAsc('b\na\nc\nb');
+  assert.strictEqual(asc, 'a\nb\nc');
+
+  const desc = funcs.sortLinesDesc('b\na\nc\nb');
+  assert.strictEqual(desc, 'c\nb\na');
+
+  console.log('All tests passed');
+}
+
+run();


### PR DESCRIPTION
## Summary
- redesign page with grid of panels
- color-coded cards perform paste-in text cleanup and conversions
- implement emdash replacer, blank line remover, comment stripper
- add Markdown/HTML rich text converters and statistics display
- include line sorter with asc/desc toggle

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843f95d83448325b44e9ef98cb36a83